### PR TITLE
fix: replace reserved keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "rm -rf ./js/* && eslint . --ext .ts --fix && tsc && echo 'Build Successful'",
 		"dev": "ts-node ./src/index.ts",
-		"deploy": "ts-node ./src/deploy-commands"
+		"cmd-deploy": "ts-node ./src/deploy-commands"
 	},
 	"license": "private",
 	"private": true,


### PR DESCRIPTION
`deploy` appears to be a reserved pnpm keyword - replacing this with `cmd-deploy` not only allows for more clarity, but rectifies this issue.